### PR TITLE
TS compiler options for node12

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,11 @@
 {
   "compilerOptions": {
-    "strict": true
+    "strict": true,
+    "module": "commonjs",
+    "target": "es2019",
+    "lib": ["es2020"],
+    "noImplicitReturns": true,
+    "noUnusedLocals": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
This PR adds several compiler options to tsconfig the most important one being the target (i.e. es2019) since it drastically improves the performance and size of the compiled js code (if unspecified, tsc will use ES3).